### PR TITLE
Resolve the issue of errors when publishing configuration files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ```
 composer require lpb/hyperf-rocketmq
 ```
+## 发布配置文件
+```
+php bin/hyperf.php vendor:publish lpb/hyperf-rocketmq
+```
+
 
 ## 新建生产者
 

--- a/src/Listener/BeforeMainServerStartListener.php
+++ b/src/Listener/BeforeMainServerStartListener.php
@@ -47,7 +47,7 @@ class BeforeMainServerStartListener implements ListenerInterface
      * Handle the Event when the event is triggered, all listeners will
      * complete before the event is returned to the EventDispatcher.
      */
-    public function process(object $event)
+    public function process(object $event): void
     {
         // Init the consumer process.
         $consumerManager = $this->container->get(ConsumerManager::class);


### PR DESCRIPTION
There will be a fatal error about declaration "BeforeMainServerStartListener::process(object $event)" when use php bin/hyperf.php vendor:publish lpb/hyperf-rocketmq。
![image](https://github.com/l417325749/hyperf-rocketmq/assets/3070542/4f302fbf-2d74-4bcd-a4f0-b140b8d9a103)
